### PR TITLE
feat: direct registration -> login transition

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -345,6 +345,30 @@
                 Login by redirect
               </button>
               <button
+                @click="registerWithRedirect"
+                class="
+                  ml-3
+                  inline-flex
+                  justify-center
+                  py-2
+                  px-4
+                  border border-transparent
+                  shadow-sm
+                  text-sm
+                  font-medium
+                  rounded-md
+                  text-white
+                  bg-indigo-600
+                  hover:bg-indigo-700
+                  focus:outline-none
+                  focus:ring-2
+                  focus:ring-offset-2
+                  focus:ring-indigo-500
+                "
+              >
+                Register by redirect
+              </button>
+              <button
                 @click="handleRedirectCallback"
                 class="
                   ml-3
@@ -816,6 +840,10 @@
           loginWithRedirect: async function () {
             await this.initClient()
             this.crossid.loginWithRedirect({})
+          },
+          registerWithRedirect: async function () {
+            await this.initClient()
+            this.crossid.registerWithRedirect({})
           },
           handleRedirectCallback: async function () {
             try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -133,6 +133,11 @@ export interface ClientOpts extends BaseClientOpts {
    * the URL used to request a logout.
    */
   logout_endpoint: string
+
+  /**
+   * the URL used to register a new user
+   */
+  registration_endpoint?: string
 }
 
 /**
@@ -254,6 +259,7 @@ export default class CrossidClient {
 
     this.state = this._stateFactory(this.opts.state_type || CACHE_SS)
     this.cache = this._cacheFactory(this.opts.cache_type || CACHE_INMEM)
+
     this._purgeIndex()
   }
 
@@ -288,6 +294,32 @@ export default class CrossidClient {
    */
   public async loginWithRedirect(opts: AuthorizationOpts) {
     const url = await this.createRedirectURL(opts)
+    window.location.replace(url)
+  }
+
+  /**
+   *
+   * @param opts Start a registration by redirecting the current window.
+   *
+   * ```js
+   * createRegistrationUrl()
+   * ```
+   *
+   * @returns
+   */
+  public async createRegistrationUrl(opts: AuthorizationOpts) {
+    if (!this.opts.registration_endpoint) {
+      throw new Error('registration_endpoint not defiend')
+    }
+    const authUrl = await this.createRedirectURL(opts)
+    const url = `${this.opts.registration_endpoint}?${createQueryString({
+      return_to: authUrl,
+    })}`
+    return url
+  }
+
+  public async registerWithRedirect(opts: AuthorizationOpts) {
+    const url = await this.createRegistrationUrl(opts)
     window.location.replace(url)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export async function newCrossidClient(opts: ClientCrossidOpts) {
   copts.token_endpoint = wn.token_endpoint
   copts.issuer = wn.issuer
   copts.logout_endpoint = copts.issuer + 'logout'
+  copts.registration_endpoint = `https://${tenant_id}.crossid.io/auth/register`
   const client = new Client(copts)
   return client
 }


### PR DESCRIPTION
Added two functions, one that returns the url for registrations that will take the user straight to consent screen, and a function that uses that url to redirect.

Added a new button to playground to use that functionality.

Will only work with crossid clients! (other providers probably work differantly)